### PR TITLE
allow slowMo option to be specified

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -58,6 +58,7 @@ node ./node_modules/puppeteer-cucumber-js/index.js # path to the module within y
 --version                       # outputs puppeteer-cucumber-js version number
 --help                          # list puppeteer-cucumber-js options
 --failFast                      # abort the run on first failure
+--slowMo <n>                    # specified amount of millseconds to slow down Puppeteer operations by. defaults to 10 ms
 ```
 
 ### Browser teardown strategy

--- a/README.MD
+++ b/README.MD
@@ -58,7 +58,7 @@ node ./node_modules/puppeteer-cucumber-js/index.js # path to the module within y
 --version                       # outputs puppeteer-cucumber-js version number
 --help                          # list puppeteer-cucumber-js options
 --failFast                      # abort the run on first failure
---slowMo <n>                    # specified amount of millseconds to slow down Puppeteer operations by. defaults to 10 ms
+--slowMo <n>                    # specified amount of milliseconds to slow down Puppeteer operations by. defaults to 10 ms
 ```
 
 ### Browser teardown strategy

--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ program
     .option('--worldParameters <JSON>', 'JSON object to pass to cucumber-js world constructor. defaults to empty', config.worldParameters)
     .option('--userAgent <string>', 'user agent string')
     .option('--failFast', 'abort the run on first failure')
-    .option('--slowMo <number>', 'specified amount of millseconds to slow down Puppeteer operations by. Defaults to ' + config.slowMo)
+    .option('--slowMo <number>', 'specified amount of milliseconds to slow down Puppeteer operations by. Defaults to ' + config.slowMo)
     .parse(process.argv);
 
 program.on('--help', function () {
@@ -120,11 +120,11 @@ global.disableLaunchReport = (program.disableLaunchReport);
 // used with world.js to determine if a screenshot should be captured on error
 global.noScreenshot = (program.noScreenshot);
 
-// set the default timeout to 10 seconds if not already globally defined or passed via the command line
-global.DEFAULT_TIMEOUT = global.DEFAULT_TIMEOUT || program.timeOut || 10 * 1000;
+// set the default timeout if not passed via the command line
+global.DEFAULT_TIMEOUT = program.timeOut || config.timeout;
 
-// set the slowMo option to 10 ms if not already globally defined or passed via the command line
-global.DEFAULT_SLOW_MO = global.DEFAULT_SLOW_MO || program.slowMo || 10;
+// set the default slowMo if not passed via the command line
+global.DEFAULT_SLOW_MO = program.slowMo || config.slowMo;
 
 // used within world.js to import shared objects into the shared namespace
 var sharedObjectsPath = path.resolve(config.sharedObjects);

--- a/index.js
+++ b/index.js
@@ -21,7 +21,8 @@ var config = {
     browserTeardownStrategy: 'always',
     timeout: 15000,
     headless: false,
-    devTools: false
+    devTools: false,
+    slowMo: 10
 };
 
 folderCheck();
@@ -35,6 +36,7 @@ global.devTools = config.devTools;
 global.userAgent = '';
 global.disableLaunchReport = false;
 global.noScreenshot = false;
+global.slowMo = config.slowMo;
 
 program
     .version(pjson.version)
@@ -52,6 +54,7 @@ program
     .option('--worldParameters <JSON>', 'JSON object to pass to cucumber-js world constructor. defaults to empty', config.worldParameters)
     .option('--userAgent <string>', 'user agent string')
     .option('--failFast', 'abort the run on first failure')
+    .option('--slowMo <number>', 'specified amount of millseconds to slow down Puppeteer operations by. Defaults to ' + config.slowMo)
     .parse(process.argv);
 
 program.on('--help', function () {
@@ -119,6 +122,9 @@ global.noScreenshot = (program.noScreenshot);
 
 // set the default timeout to 10 seconds if not already globally defined or passed via the command line
 global.DEFAULT_TIMEOUT = global.DEFAULT_TIMEOUT || program.timeOut || 10 * 1000;
+
+// set the slowMo option to 10 ms if not already globally defined or passed via the command line
+global.DEFAULT_SLOW_MO = global.DEFAULT_SLOW_MO || program.slowMo || 10;
 
 // used within world.js to import shared objects into the shared namespace
 var sharedObjectsPath = path.resolve(config.sharedObjects);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "puppeteer-cucumber-js",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "description": "Browser Automation framework using puppeteer and cucumber-js",
   "main": "index.js",
   "bin": {

--- a/runtime/world.js
+++ b/runtime/world.js
@@ -103,7 +103,7 @@ module.exports = async function () {
                 product: browserName || 'chrome',
                 defaultViewport: null,
                 devtools: devTools === true,
-                slowMo: 10, // slow down by 10ms so we can view in headful mode
+                slowMo: global.DEFAULT_SLOW_MO, // slow down by specified ms so we can view in headful mode
                 args: [
                     `--window-size=${browserWidth},${browserHeight}`
                 ]


### PR DESCRIPTION
Exposes puppeteers `slowMo` option. We can configure using for e.g. `--slowMo 100` when running tests. Allows us to slow down puppeteer operations by a number of ms.